### PR TITLE
CHAPTER 2 完了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ ipython_config.py
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Original
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Original
 .idea
+*:Zone.Identifier

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pytest = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 pytest = "*"
+cards = {path = "./cards_proj"}
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 テスト駆動 Python 第２版 の Hands-on 
 
 ---
+## Test の結果
+| 表示          | 内容                                                     | 備考                                                   |
+|-------------|--------------------------------------------------------|------------------------------------------------------|
+| PASSED (.)  | Test が正常に実行されたことを意味する。                                 |                                                      |
+| FAILED (F)  | Test が正常に実行されなかったことを意味する。                              |                                                      |
+| SKIPPED (s) | この Test が Skip されたことを意味する。                             | `@pytest.mark.skip()` または `@pytest.mark.skipf()` を使う |
+ | XFAIL (x)   | 失敗するはずの Test が実行され、想定どおりに失敗したことを意味する。                  | `@pytest.mark.xfail()` を使う                           |
+| XPASS (X)   | xfail Maker が付いた Test の実行が想定に反して成功したことを意味する。           |                                                      |
+| ERROR (E)   | 例外が Test関数の実行中ではなく Fixture または Hook関数の実行中に発生したことを意味する。 |                                                      |
 
 ### Tset で使用する Sample Application の Source-code
 [https://media.pragprog.com/titles/bopytest2/code/bopytest2-code.zip](https://media.pragprog.com/titles/bopytest2/code/bopytest2-code.zip)
+

--- a/README.md
+++ b/README.md
@@ -50,3 +50,17 @@ Test を駆動するときの初期状態。Action を実行するために Data
 - Test Class の階層を利用して Helper-method を継承することなど可能だが極力避ける。
   ※ Test-class の継承を使って何か凝ったことをしようとすると、混乱の原因になる。
 
+---
+
+## Test の一部を実行する方法
+
+| 実行する部分               | 構文                                                     |
+|----------------------|--------------------------------------------------------|
+| Test-method を１つだけ    | `pytest <pass> test_module.py::TestClass::test_method` |
+| Class内のすべての Test     | `pytest <pass> test_module.py::TestClass`              |
+| Test関数を１つだけ          | `pytest <pass> test_module.py::test_function`          |
+| Module内のすべての Test    | `pytest <pass>`                                        |
+| Directory内のすべての Test | `pytest -, <pattern>`                                  |
+
+-k flag を and, not, or の３つの Keyword と組み合わせると非常に柔軟な指定が可能になり、実行したい Test を正確に選択できるようになる。
+Debug や新しい Test の開発を行なっているときに非常に役立つ。

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ Test を駆動するときの初期状態。Action を実行するために Data
 ### 3. Then / Assert
 
 結果、または最終状態の期待値。Test の最後に、Action の結果が期待どおりの振る舞いになったことを確認する。
+
+---
+
+## Test の OPP(Object Oriented Programing)の考察
+
+- 基本的には、Test をまとめて実行しやすくする目的のみで利用する。
+- Test Class の階層を利用して Helper-method を継承することなど可能だが極力避ける。
+  ※ Test-class の継承を使って何か凝ったことをしようとすると、混乱の原因になる。
+

--- a/README.md
+++ b/README.md
@@ -1,17 +1,43 @@
 # test_driven_python
-テスト駆動 Python 第２版 の Hands-on 
+
+テスト駆動 Python 第２版 の Hands-on
 
 ---
+
 ## Test の結果
+
 | 表示          | 内容                                                     | 備考                                                   |
 |-------------|--------------------------------------------------------|------------------------------------------------------|
 | PASSED (.)  | Test が正常に実行されたことを意味する。                                 |                                                      |
 | FAILED (F)  | Test が正常に実行されなかったことを意味する。                              |                                                      |
 | SKIPPED (s) | この Test が Skip されたことを意味する。                             | `@pytest.mark.skip()` または `@pytest.mark.skipf()` を使う |
- | XFAIL (x)   | 失敗するはずの Test が実行され、想定どおりに失敗したことを意味する。                  | `@pytest.mark.xfail()` を使う                           |
+| XFAIL (x)   | 失敗するはずの Test が実行され、想定どおりに失敗したことを意味する。                  | `@pytest.mark.xfail()` を使う                           |
 | XPASS (X)   | xfail Maker が付いた Test の実行が想定に反して成功したことを意味する。           |                                                      |
 | ERROR (E)   | 例外が Test関数の実行中ではなく Fixture または Hook関数の実行中に発生したことを意味する。 |                                                      |
 
 ### Tset で使用する Sample Application の Source-code
+
 [https://media.pragprog.com/titles/bopytest2/code/bopytest2-code.zip](https://media.pragprog.com/titles/bopytest2/code/bopytest2-code.zip)
 
+---
+
+## Test を作成する際の構造の考え方
+
+Test を構造化すると
+
+- Test関数が整理された状態が保たれる。
+- Test の対象が１つの振る舞いに絞られる。
+- １つの初期状態に焦点を合わせると、同じ Action を使って Test する必要があるかもしれない他の状態について検討しやすくなる。
+- １つの理想的な結果に焦点を合わせると、失敗状態や Error状態など、それ以外に予想される結果について考えるのに役立つ。
+
+### 1. Given / Arrange
+
+Test を駆動するときの初期状態。Action を実行するために Data または環境を整える。
+
+### 2. When / Act
+
+ある Action を実行する。その振る舞いが正しいかどうかを確認することが Test の焦点となる。
+
+### 3. Then / Assert
+
+結果、または最終状態の期待値。Test の最後に、Action の結果が期待どおりの振る舞いになったことを確認する。

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # test_driven_python
 テスト駆動 Python 第２版 の Hands-on 
+
+---
+
+### Tset で使用する Sample Application の Source-code
+[https://media.pragprog.com/titles/bopytest2/code/bopytest2-code.zip](https://media.pragprog.com/titles/bopytest2/code/bopytest2-code.zip)

--- a/cards_proj/LICENSE
+++ b/cards_proj/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018, Brian Okken
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cards_proj/README.md
+++ b/cards_proj/README.md
@@ -1,0 +1,59 @@
+cards
+=====
+
+Project task tracking / todo list
+
+Usage
+-----
+
+Here's a demo of how it works:
+
+    $ cards add a todo
+
+    $ cards add -o Brian another task
+
+    $ cards list
+         ╷       ╷       ╷
+      ID │ state │ owner │ summary
+    ╺━━━━┿━━━━━━━┿━━━━━━━┿━━━━━━━━━━━━━━╸
+      1  │ todo  │       │ a todo
+      2  │ todo  │ Brian │ another task
+         ╵       ╵       ╵
+
+    $ cards update 1 -o Brian
+
+    $ cards finish 1
+
+    $ cards
+      ID │ state │ owner │ summary
+    ╺━━━━┿━━━━━━━┿━━━━━━━┿━━━━━━━━━━━━━━╸
+      1  │ done  │ Brian │ a todo
+      2  │ todo  │ Brian │ another task
+         ╵       ╵       ╵
+
+    $ cards delete 1
+
+    $ cards
+      ID │ state │ owner │ summary
+    ╺━━━━┿━━━━━━━┿━━━━━━━┿━━━━━━━━━━━━━━╸
+      2  │ todo  │ Brian │ another task
+         ╵       ╵       ╵
+
+    $ cards --help
+    Usage: cards [OPTIONS] COMMAND [ARGS]...
+
+      Cards is a small command line task tracking application.
+
+    Options:
+      --help  Show this message and exit.
+
+    Commands:
+      add      Add a card to db.
+      config   List the path to the Cards db.
+      count    Return number of cards in db.
+      delete   Remove card in db with given id.
+      finish   Set a card state to 'done'.
+      list     List cards in db.
+      start    Set a card state to 'in prog'.
+      update   Modify a card in db with given id with new info.
+      version  Return version of cards application

--- a/cards_proj/pyproject.toml
+++ b/cards_proj/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "cards"
+authors = [{name = "Brian Okken", email = "brian+pypi@pythontest.com"}]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+]
+requires-python=">=3.7"
+dynamic = ["version", "description"]
+dependencies = [
+    "tinydb==4.5.1",
+    "typer==0.3.2",
+    "rich==10.7.0"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "faker",
+    "tox",
+    "coverage",
+    "pytest-cov",
+]
+
+[project.urls]
+Home = "https://github.com/okken/cards"
+
+[project.scripts]
+cards = "cards:app"
+

--- a/cards_proj/src/cards/__init__.py
+++ b/cards_proj/src/cards/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for cards."""
+
+__version__ = "1.0.0"
+
+from .api import *  # noqa
+from .cli import app  # noqa

--- a/cards_proj/src/cards/api.py
+++ b/cards_proj/src/cards/api.py
@@ -1,0 +1,122 @@
+"""
+API for the cards project
+"""
+from dataclasses import asdict
+from dataclasses import dataclass
+from dataclasses import field
+
+from .db import DB
+
+__all__ = [
+    "Card",
+    "CardsDB",
+    "CardsException",
+    "MissingSummary",
+    "InvalidCardId",
+]
+
+
+@dataclass
+class Card:
+    summary: str = None
+    owner: str = None
+    state: str = "todo"
+    id: int = field(default=None, compare=False)
+
+    @classmethod
+    def from_dict(cls, d):
+        return Card(**d)
+    def to_dict(self):
+        return asdict(self)
+
+
+class CardsException(Exception):
+    pass
+
+
+class MissingSummary(CardsException):
+    pass
+
+
+class InvalidCardId(CardsException):
+    pass
+
+
+class CardsDB:
+    def __init__(self, db_path):
+        self._db_path = db_path
+        self._db = DB(db_path, ".cards_db")
+
+    def add_card(self, card: Card) -> int:
+        """Add a card, return the id of card."""
+        if not card.summary:
+            raise MissingSummary
+        if card.owner is None:
+            card.owner = ""
+        id = self._db.create(card.to_dict())
+        self._db.update(id, {"id": id})
+        return id
+
+    def get_card(self, card_id: int) -> Card:
+        """Return a card with a matching id."""
+        db_item = self._db.read(card_id)
+        if db_item is not None:
+            return Card.from_dict(db_item)
+        else:
+            raise InvalidCardId(card_id)
+
+    def list_cards(self, owner=None, state=None):
+        """Return a list of cards."""
+        all = self._db.read_all()
+        if (owner is not None) and (state is not None):
+            return [
+                Card.from_dict(t)
+                for t in all
+                if (t["owner"] == owner and t["state"] == state)
+            ]
+        elif owner is not None:
+            return [
+                Card.from_dict(t) for t in all if t["owner"] == owner
+            ]
+        elif state is not None:
+            return [
+                Card.from_dict(t) for t in all if t["state"] == state
+            ]
+        else:
+            return [Card.from_dict(t) for t in all]
+
+    def count(self) -> int:
+        """Return the number of cards in db."""
+        return self._db.count()
+
+    def update_card(self, card_id: int, card_mods: Card) -> None:
+        """Update a card with modifications."""
+        try:
+            self._db.update(card_id, card_mods.to_dict())
+        except KeyError as exc:
+            raise InvalidCardId(card_id) from exc
+
+    def start(self, card_id: int):
+        """Set a card state to 'in prog'."""
+        self.update_card(card_id, Card(state="in prog"))
+
+    def finish(self, card_id: int):
+        """Set a card state to 'done'."""
+        self.update_card(card_id, Card(state="done"))
+
+    def delete_card(self, card_id: int) -> None:
+        """Remove a card from db with given card_id."""
+        try:
+            self._db.delete(card_id)
+        except KeyError as exc:
+            raise InvalidCardId(card_id) from exc
+
+    def delete_all(self) -> None:
+        """Remove all cards from db."""
+        self._db.delete_all()
+
+    def close(self):
+        self._db.close()
+
+    def path(self):
+        return self._db_path

--- a/cards_proj/src/cards/cli.py
+++ b/cards_proj/src/cards/cli.py
@@ -1,0 +1,140 @@
+"""Command Line Interface (CLI) for cards project."""
+import os
+from io import StringIO
+import pathlib
+import rich
+from rich.table import Table
+from contextlib import contextmanager
+from typing import List
+
+import cards
+
+import typer
+
+app = typer.Typer(add_completion=False)
+
+
+@app.command()
+def version():
+    """Return version of cards application"""
+    print(cards.__version__)
+
+
+@app.command()
+def add(
+    summary: List[str], owner: str = typer.Option(None, "-o", "--owner")
+):
+    """Add a card to db."""
+    summary = " ".join(summary) if summary else None
+    with cards_db() as db:
+        db.add_card(cards.Card(summary, owner, state="todo"))
+
+
+@app.command()
+def delete(card_id: int):
+    """Remove card in db with given id."""
+    with cards_db() as db:
+        try:
+            db.delete_card(card_id)
+        except cards.InvalidCardId:
+            print(f"Error: Invalid card id {card_id}")
+
+
+@app.command("list")
+def list_cards(
+    owner: str = typer.Option(None, "-o", "--owner"),
+    state: str = typer.Option(None, "-s", "--state"),
+):
+    """
+    List cards in db.
+    """
+    with cards_db() as db:
+        the_cards = db.list_cards(owner=owner, state=state)
+        table = Table(box=rich.box.SIMPLE)
+        table.add_column("ID")
+        table.add_column("state")
+        table.add_column("owner")
+        table.add_column("summary")
+        for t in the_cards:
+            owner = "" if t.owner is None else t.owner
+            table.add_row(str(t.id), t.state, owner, t.summary)
+        out = StringIO()
+        rich.print(table, file=out)
+        print(out.getvalue())
+
+
+@app.command()
+def update(
+    card_id: int,
+    owner: str = typer.Option(None, "-o", "--owner"),
+    summary: List[str] = typer.Option(None, "-s", "--summary"),
+):
+    """Modify a card in db with given id with new info."""
+    summary = " ".join(summary) if summary else None
+    with cards_db() as db:
+        try:
+            db.update_card(
+                card_id, cards.Card(summary, owner, state=None)
+            )
+        except cards.InvalidCardId:
+            print(f"Error: Invalid card id {card_id}")
+
+
+@app.command()
+def start(card_id: int):
+    """Set a card state to 'in prog'."""
+    with cards_db() as db:
+        try:
+            db.start(card_id)
+        except cards.InvalidCardId:
+            print(f"Error: Invalid card id {card_id}")
+
+
+@app.command()
+def finish(card_id: int):
+    """Set a card state to 'done'."""
+    with cards_db() as db:
+        try:
+            db.finish(card_id)
+        except cards.InvalidCardId:
+            print(f"Error: Invalid card id {card_id}")
+
+
+@app.command()
+def config():
+    """List the path to the Cards db."""
+    with cards_db() as db:
+        print(db.path())
+
+
+@app.command()
+def count():
+    """Return number of cards in db."""
+    with cards_db() as db:
+        print(db.count())
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context):
+    """
+    Cards is a small command line task tracking application.
+    """
+    if ctx.invoked_subcommand is None:
+        list_cards(owner=None, state=None)
+
+
+def get_path():
+    db_path_env = os.getenv("CARDS_DB_DIR", "")
+    if db_path_env:
+        db_path = pathlib.Path(db_path_env)
+    else:
+        db_path = pathlib.Path.home() / "cards_db"
+    return db_path
+
+
+@contextmanager
+def cards_db():
+    db_path = get_path()
+    db = cards.CardsDB(db_path)
+    yield db
+    db.close()

--- a/cards_proj/src/cards/db.py
+++ b/cards_proj/src/cards/db.py
@@ -1,0 +1,38 @@
+"""
+DB for the cards project
+"""
+import tinydb
+
+
+class DB:
+    def __init__(self, db_path, db_file_prefix):
+        self._db = tinydb.TinyDB(
+            db_path / f"{db_file_prefix}.json", create_dirs=True
+        )
+
+    def create(self, item: dict) -> int:
+        id = self._db.insert(item)
+        return id
+
+    def read(self, id: int):
+        item = self._db.get(doc_id=id)
+        return item
+
+    def read_all(self):
+        return self._db
+
+    def update(self, id: int, mods) -> None:
+        changes = {k: v for k, v in mods.items() if v is not None}
+        self._db.update(changes, doc_ids=[id])
+
+    def delete(self, id: int) -> None:
+        self._db.remove(doc_ids=[id])
+
+    def delete_all(self) -> None:
+        self._db.truncate()
+
+    def count(self) -> int:
+        return len(self._db)
+
+    def close(self):
+        self._db.close()

--- a/chapter01/test_one.py
+++ b/chapter01/test_one.py
@@ -1,0 +1,2 @@
+def test_passing():
+    assert(1, 2, 3) == (1, 2, 3)

--- a/chapter01/test_practis.py
+++ b/chapter01/test_practis.py
@@ -1,0 +1,10 @@
+def test_in():
+    assert 1 in [2, 3, 4]
+
+
+def test_comparison():
+    assert a < b
+
+
+def test_not_in():
+    assert 'fizz' not in 'fizzbuzz'

--- a/chapter01/test_two.py
+++ b/chapter01/test_two.py
@@ -1,0 +1,2 @@
+def test_failing():
+    assert (1, 2, 3) == (3, 2, 1)

--- a/chapter02/test_alt_fail.py
+++ b/chapter02/test_alt_fail.py
@@ -1,0 +1,9 @@
+import pytest
+from cards import Card
+
+
+def test_with_fail():
+    c1 = Card('sit there', 'brian')
+    c2 = Card('do something', 'okken')
+    if c1 != c2:
+        pytest.fail("they don't match")

--- a/chapter02/test_card.py
+++ b/chapter02/test_card.py
@@ -1,0 +1,65 @@
+from cards import Card
+
+# 構造の仕組みを理解できているかどうかを確認する Test.
+
+# 目的
+## 構造の仕組みを理解できているかの Check.
+## 構造の仕組みを他者や未来の自分のためへの文書化
+
+
+def test_field_access():
+    c = Card('something', 'brian', 'todo', 123)
+    assert c.summary == 'something'
+    assert c.owner == 'brian'
+    assert c.state == 'todo'
+    assert c.id == 123
+
+
+def test_defaults():
+    c = Card()
+    assert c.summary is None
+    assert c.owner is None
+    assert c.state == 'todo'
+    assert c.id is None
+
+
+def test_equality():
+    c1 = Card('something', 'brian', 'todo', 123)
+    c2 = Card('something', 'brian', 'todo', 123)
+    assert c1 == c2
+
+
+def test_equality_with_diff_ids():
+    c1 = Card('something', 'brian', 'todo', 123)
+    c2 = Card('something', 'brian', 'todo', 4567)
+    assert c1 == c2
+
+
+def test_inequality():
+    c1 = Card('something', 'brian', 'todo', 123)
+    c2 = Card('completely different', 'okken', 'done', 123)
+    assert c1 != c2
+
+
+def test_from_dict():
+    c1 = Card('something', 'brian', 'todo', 123)
+    c2_dict = {
+        'summary': 'something',
+        'owner': 'brian',
+        'state': 'todo',
+        'id': 123,
+    }
+    c2 = Card.from_dict(c2_dict)
+    assert c1 == c2
+
+
+def test_to_dict():
+    c1 = Card('something', 'brian', 'todo', 123)
+    c2 = c1.to_dict()
+    c2_expected = {
+        'summary': 'something',
+        'owner': 'brian',
+        'state': 'todo',
+        'id': 123,
+    }
+    assert c2 == c2_expected

--- a/chapter02/test_card_fail.py
+++ b/chapter02/test_card_fail.py
@@ -1,0 +1,11 @@
+from cards import Card
+
+
+def test_equality_fail():
+    c1 = Card('sit there', 'brian')
+    c2 = Card('do something', 'okken')
+    assert c1 == c2
+
+
+if __name__ == '__main__':
+   test_equality_fail()

--- a/chapter02/test_classes.py
+++ b/chapter02/test_classes.py
@@ -1,0 +1,18 @@
+from cards import Card
+
+
+class TestEquality:
+    def test_equality(self):
+        c1 = Card('something', 'brian', 'todo', 123)
+        c2 = Card('something', 'brian', 'todo', 123)
+        assert c1 == c2
+
+    def test_equality_with_diff_ids(self):
+        c1 = Card('something', 'brian', 'todo', 123)
+        c2 = Card('something', 'brian', 'todo', 4567)
+        assert c1 == c2
+
+    def test_inequality(self):
+        c1 = Card('something', 'brian', 'todo', 123)
+        c2 = Card('completely different', 'okken', 'todo', 123)
+        assert c1 != c2

--- a/chapter02/test_exceptions.py
+++ b/chapter02/test_exceptions.py
@@ -1,0 +1,23 @@
+import pytest
+import cards
+
+
+def test_no_path_raises():
+    with pytest.raises(TypeError):  # Code-block の何かが TypeError例外を発生させるはずことを意味する。
+        cards.CardsDB()
+        # 例外が発生しない場合、Test に失敗する
+        # 指定した例外と異なる例外が発生した場合も Test は失敗する。
+
+
+def test_raises_with_info():
+    match_regex = 'missing 1 .* positional argument'
+    with pytest.raises(TypeError, match=match_regex):  # match= は、正規表現を受け取って例外Message と照合する。
+        cards.CardsDB()
+
+
+def test_raises_with_info_alt():
+    with pytest.raises(TypeError) as exc_info:  # Custom例外の場合は、as *** と変数名を使って例外の Parameter に関する情報を取得する。
+        cards.CardsDB()
+    expected = 'missing 1 required positional argument'
+    assert expected in str(exc_info.value)
+    # exe_info のObject型は、ExceptionInfo になる。

--- a/chapter02/test_experiment.py
+++ b/chapter02/test_experiment.py
@@ -1,0 +1,5 @@
+import cards
+
+
+def test_no_path_fail():
+    cards.CardsDB()

--- a/chapter02/test_helper.py
+++ b/chapter02/test_helper.py
@@ -1,0 +1,21 @@
+from cards import Card
+import pytest
+
+
+def assert_identical(c1: Card, c2: Card):
+    __tracebackhide__ = True
+    assert c1 == c2
+    if c1.id != c2.id:
+        pytest.fail(f"id's don't match. {c1.id} != {c2.id}")
+
+
+def test_identical():
+    c1 = Card('foo', id=123)
+    c2 = Card('foo', id=123)
+    assert_identical(c1, c2)
+
+
+def test_identical_fail():
+    c1 = Card('foo', id=123)
+    c2 = Card('foo', id=456)
+    assert_identical(c1, c2)

--- a/chapter02/test_structure.py
+++ b/chapter02/test_structure.py
@@ -1,0 +1,22 @@
+from cards import Card
+
+
+def test_to_dict():
+    # GIVEN a Crad object with known contents.
+    # 前提: 既知の値が設定された Card object が与えられたとすれば
+    c1 = Card('something', 'brian', 'todo', 123)
+
+    # WHEN we call to_dict() on the object.
+    # もし：この Object で to_dict()を呼び出したときに
+    c2 = c1.to_dict()
+
+    # THEN the result will be a dictionary with known content.
+    # ならば: 既知の値が設定された Dictionary が返される
+    c2_expected = {
+        'summary': 'something',
+        'owner': 'brian',
+        'state': 'todo',
+        'id': 123,
+    }
+    assert c2 == c2_expected
+


### PR DESCRIPTION
- `pytest` は `assert` に書き換えを行なうため、Python の標準の`assert`式を使うことができる。

- AssertionError fail() の呼び出し、または補足されなかった例外によって Test が失敗することがある。

- 想定されている例外の Test には、`pytest.raises()`を使う。

- Given-When-Then または、Arrange-Act-Assert と呼ばれる Pattern は Test をうまく構造化するのに役立つ。

- Test は Class にまとめることができる。

- Debug の際には、Test をほんの一部だけ実行できると便利である。`pytest`には、Test の一部を実行する方法が何種類かある。

- -vv Comand-line-flag を使うと、Test が失敗した場合により詳細な情報を表示できる。
